### PR TITLE
refactor gcd iaccept, remove hardcoded prefix

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -86,7 +86,7 @@ var randSong = ['https://www.youtube.com/watch?v=pYCPGEEvkJU','https://m.youtube
 var randVideo = ['https://m.youtube.com/watch?v=W9gxFkOz2_4'];
 var commRand = false;
 var commands = ['ping', 'music', 'portalCat', 'changeMyNickname', 'knockknock', 'randVideo', 'randSong', 'videoSongSuggestions', 'guildLink', 'help', 'rcCM', 'createPoll', 'pollOptions', 'pollResults', 'addCustomResponse', 'vote', 'closePoll', 'createAtappPoll', 'pollAtappOptions', 'addCustomatAtappResponse', 'pollAtappResults', 'votAtapp', 'closeAtapp', 'customCommand', 'feedback', 'suggest', 'userInfo', 'test', 'getChannelID', 'tto', 'findRoleID', 'getServerID', 'inviteInfo', 'purge','toggleNSFW', 'toggleJoinNotifications'];
-var commandHelp = ['Replys "Pong!", perfect for a game of never-ending ping pong.', 'Replys with the lyrics of a random song.', 'Replys with an animated emoji of a cat jumping into a portal.', 'Changes your nickname to a random nickname from a list.', 'Replys to YOUR knock-knock joke.', 'Replys with a link to a user-suggested video.', 'Replys with a link to a user-suggested song.', 'Sends your video/song suggestion to the owner for review. \nSuggestions must be (mainly) English, curse-free, and under 15 minutes long.', 'Replys with an invite to the GCD Support Server.', 'There are two ways to use this command. \nhelp: DMs you a complete list of commands and descriptions. \nhelp [command]: Replys with a description of that command.', 'Usage: rcCM [@role] [cmd] \nAllows users to join/leave the mentioned role by saying ' + prefix + 'cmd \nTo run the command, your highest role must have admin/manage roles, and must be higher than the role you are trying to give access to.', 'Follow directions after using this command to create a poll users can respond to.', 'Replys with the options to the current poll.', 'Replys with the current results of the current poll.', 'Usage: addCustomResponse [custom] \nAllows you to add a custom response to a poll.', 'Usage: vote [optionNum] \nAdds your vote to the option specified, you can only vote once per poll.', 'Can only be done by the poll opener, closes the current poll.', 'After using this command, follow directions to create an \'All that apply\' poll.', 'Replys with the options for the current \'All that apply\' poll.', 'Usage: addCustomAtappResponse [custom] \nAllows you to add a custom response to an \'All that apply\' poll.', 'Replys with the current results for the current \'All that apply\' poll.', 'Allows you to vote for an option in an \'All that apply\' poll. Can be used multiple times.', 'Allows the owner of an \'All that apply\' poll to close it.', 'Usage: customCommand[1/2/3] \nAllows users to create custom (temporary) commands by running the command and following instructions', 'Usage: feeback [feedback] \nSends your feedback to the creator.', 'Usage: suggest [suggestion] \nSends your suggestion to the creator.', 'Usage: useInfo [@user] \nReplys with information about the mentioned user.', 'Replys with a sample of code currently in development.', 'Replys with the ID of the current channel.', 'Usage: tto [input] \nRepeats the input back', 'Usage: findRoleID [@role] \nReplys with the ID of the mentioned role.', 'Replys with the ID of the current server.', 'Usage: inviteInfo [invite] \nReplys with info about the invite given.', 'Usage: purge [num] \nPurges the number of messages requested (This number does not include the gcd.purge message, which is also deleted)','Toggles the NSFW quality for the current channel. \nTo run the command, your highest role must have admin/manage channels.', 'Toggles join notifications for your server. \nTo run the command, you must be the sesrver owner.'];
+var commandHelp = ['Replys "Pong!", perfect for a game of never-ending ping pong.', 'Replys with the lyrics of a random song.', 'Replys with an animated emoji of a cat jumping into a portal.', 'Changes your nickname to a random nickname from a list.', 'Replys to YOUR knock-knock joke.', 'Replys with a link to a user-suggested video.', 'Replys with a link to a user-suggested song.', 'Sends your video/song suggestion to the owner for review. \nSuggestions must be (mainly) English, curse-free, and under 15 minutes long.', 'Replys with an invite to the GCD Support Server.', 'There are two ways to use this command. \nhelp: DMs you a complete list of commands and descriptions. \nhelp [command]: Replys with a description of that command.', 'Usage: rcCM [@role] [cmd] \nAllows users to join/leave the mentioned role by saying ' + prefix + 'cmd \nTo run the command, your highest role must have admin/manage roles, and must be higher than the role you are trying to give access to.', 'Follow directions after using this command to create a poll users can respond to.', 'Replys with the options to the current poll.', 'Replys with the current results of the current poll.', 'Usage: addCustomResponse [custom] \nAllows you to add a custom response to a poll.', 'Usage: vote [optionNum] \nAdds your vote to the option specified, you can only vote once per poll.', 'Can only be done by the poll opener, closes the current poll.', 'After using this command, follow directions to create an \'All that apply\' poll.', 'Replys with the options for the current \'All that apply\' poll.', 'Usage: addCustomAtappResponse [custom] \nAllows you to add a custom response to an \'All that apply\' poll.', 'Replys with the current results for the current \'All that apply\' poll.', 'Allows you to vote for an option in an \'All that apply\' poll. Can be used multiple times.', 'Allows the owner of an \'All that apply\' poll to close it.', 'Usage: customCommand[1/2/3] \nAllows users to create custom (temporary) commands by running the command and following instructions', 'Usage: feeback [feedback] \nSends your feedback to the creator.', 'Usage: suggest [suggestion] \nSends your suggestion to the creator.', 'Usage: useInfo [@user] \nReplys with information about the mentioned user.', 'Replys with a sample of code currently in development.', 'Replys with the ID of the current channel.', 'Usage: tto [input] \nRepeats the input back', 'Usage: findRoleID [@role] \nReplys with the ID of the mentioned role.', 'Replys with the ID of the current server.', 'Usage: inviteInfo [invite] \nReplys with info about the invite given.', 'Usage: purge [num] \nPurges the number of messages requested (This number does not include the ' + prefix + 'purge message, which is also deleted)','Toggles the NSFW quality for the current channel. \nTo run the command, your highest role must have admin/manage channels.', 'Toggles join notifications for your server. \nTo run the command, you must be the sesrver owner.'];
 var pfMsgLength = 15;
 
 //team blue 499003285106196480
@@ -423,17 +423,19 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 	}
 	
 	dtb.query('SELECT * FROM profile WHERE id = \'' + userID + '\'', function(e, r){
-		if (bot.directMessages[channelID] && (message == "gcd.accept iAcPT") && r.rows[0] == undefined){
-			dtb.query('INSERT INTO profile(id, username, nickname, lastuse, lastcommand, totalnum, lastvote, totalvote, selfdesc) VALUES (' + userID + ', \'' + bot.users[userID].username + '\', \'Use "gcd.pfNickname [nickname]" to set\', \'NA\', \'NA\', 0, \'NA\', 0, \'Use "gcd.pfBio [biography]" to set\')');
-			bot.sendMessage({
-				to: channelID,
-				message: 'Congrats! You created a profile!'
-			});
-		} else if(bot.directMessages[channelID] && (message == "gcd.accept iAcPT") && r.rows[0] != undefined){
-			bot.sendMessage({
-				to: channelID,
-				message: 'You already have a profile.'
-			});
+		if (bot.directMessages[channelID] && (message == prefix + "accept iAcPT")){
+			if (r.rows[0] == undefined){
+				dtb.query('INSERT INTO profile(id, username, nickname, lastuse, lastcommand, totalnum, lastvote, totalvote, selfdesc) VALUES (' + userID + ', \'' + bot.users[userID].username + '\', \'Use "' + prefix + 'pfNickname [nickname]" to set\', \'NA\', \'NA\', 0, \'NA\', 0, \'Use "' + prefix + 'pfBio [biography]" to set\')');
+				bot.sendMessage({
+					to: channelID,
+					message: 'Congrats! You created a profile!'
+				});
+			} else {
+				bot.sendMessage({
+					to: channelID,
+					message: 'You already have a profile.'
+				});
+			}
 		}
 	});
 	
@@ -452,7 +454,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 		bot.setPresence({
 			game: {
 				type: 0,
-				name: 'in ' + Object.keys(bot.servers).length + ' servers! gcd.help | gcd.guildLink'
+				name: 'in ' + Object.keys(bot.servers).length + ' servers! ' + prefix + 'help | ' + prefix + 'guildLink'
 			}
 		}, function(err, res){
 			if (err) throw err
@@ -509,7 +511,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 			bot.setPresence({
 				game: {
 					type: 0,
-					name: 'in ' + Object.keys(bot.servers).length + ' servers! gcd.help | gcd.guildLink'
+					name: 'in ' + Object.keys(bot.servers).length + ' servers! ' + prefix + 'help | ' + prefix + 'guildLink'
 				}
 			}, function(err, res){
 				if (err) throw err
@@ -871,7 +873,6 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 
 		//Doesn't let bots run commands, doesn't run commands in bot list server, yeah.
 	    var splice = 4;
-	    prefix = 'gcd.';
 	    if (serverID == '669733918378819584'){
 		prefix = ';';
 		splice = 1;
@@ -959,7 +960,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 					if (message.length < 11 || !(message.substring(9, 10) == ' ')){
 						bot.sendMessage({
 							to: channelID,
-							message: 'Please include the number of messages to purge (gcd.purge [num])'
+							message: 'Please include the number of messages to purge (' + prefix + 'purge [num])'
 						});
 					} else if (parseInt(message.substring(10)) > 100){
 						bot.sendMessage({
@@ -1097,7 +1098,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 							if (r.rows[0] == undefined){
 								bot.sendMessage({
 									to: channelID,
-									message: 'Your server is not ready to perform this action. Please run "gcd.updateVersion" first.'
+									message: 'Your server is not ready to perform this action. Please run "' + prefix + 'updateVersion" first.'
 								});
 							}
 						}
@@ -1486,7 +1487,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 						bot.setPresence({
 							game: {
 								type: 0,
-								name: 'in ' + Object.keys(bot.servers).length + ' servers! gcd.help | gcd.guildLink'
+								name: 'in ' + Object.keys(bot.servers).length + ' servers! ' + prefix + 'help | ' + prefix + 'guildLink'
 							}
 						}, function(err, res){
 							if (err) throw err
@@ -1499,7 +1500,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 					bot.setPresence({
 						game: {
 							type: 0,
-							name: 'in ' + Object.keys(bot.servers).length + ' servers! gcd.help | gcd.guildLink'
+							name: 'in ' + Object.keys(bot.servers).length + ' servers! ' + prefix + 'help | ' + prefix + 'guildLink'
 						}
 					}, function(err, res){
 						if (err) throw err
@@ -1829,7 +1830,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 					console.log('test');
 					bot.sendMessage({
 						to: userID,
-						message: 'Our current commands are as follows. \n \n**Entertainment** :tada: \nping - responds "Pong!", enjoy yourself some ping pong. \nmusic - displays the lyrics of a random song from a list \nportalCat - displays a fun infinite gif of a cat jumping into a portal. \nchangeMyNickname - changes your nickname to a random nickname from a list. \nknockknock - responds to YOUR knock knock joke. \nrandVideo - gives a link to a random video. \nrandSong - gives a link to a random song. \nvideoSongSuggestions - suggest your favorite video/song for randVideo/randSong, all suggestions must be English, curse free, and less than 15 minutes long. \n \n**Useful** :paperclip: \nguildLink - gives the invite for the GCD help server. \nhelp - displays this, duh. \nhelp [command] - displays information about the given command. \nrcCM [\@role] [cmd] - Allows a user to join/leave [\@role] by saying the prefix + [cmd]. To run the command, your highest role must have admin/manage roles, and must be higher than the role you are trying to give access to. \ntoggleNSFW - Will toggle the NSFW quality for the channel you run it in. Your highest role in the server must have admin/manage channels to do this. \npurge [num] - Purges the number of messages requested (This number does not include the gcd.purge message, which is also deleted). \ncreatePoll - Follow instruction to create a poll. \npollOptions - displays the options to the current poll. \npollResults - displays the current results of the poll. \naddCustomResponse [custom] - allows users to add a custom response to a poll. \nvote [optionNum] - votes for the option number given. \nclosePoll - Can only be done by poll creator, closes poll and displas results. \nall that apply polls, createAtappPoll, pollAtappOptions, addCustomAtappResponse [custom], pollAtappResults, voteAtapp [vote], closeAtappPoll. These work the same as regular polls, but users can choose multiple responses \ncustomCommand[1/2/3] - allows users to create custom commands by following instructions.'
+						message: 'Our current commands are as follows. \n \n**Entertainment** :tada: \nping - responds "Pong!", enjoy yourself some ping pong. \nmusic - displays the lyrics of a random song from a list \nportalCat - displays a fun infinite gif of a cat jumping into a portal. \nchangeMyNickname - changes your nickname to a random nickname from a list. \nknockknock - responds to YOUR knock knock joke. \nrandVideo - gives a link to a random video. \nrandSong - gives a link to a random song. \nvideoSongSuggestions - suggest your favorite video/song for randVideo/randSong, all suggestions must be English, curse free, and less than 15 minutes long. \n \n**Useful** :paperclip: \nguildLink - gives the invite for the GCD help server. \nhelp - displays this, duh. \nhelp [command] - displays information about the given command. \nrcCM [\@role] [cmd] - Allows a user to join/leave [\@role] by saying the prefix + [cmd]. To run the command, your highest role must have admin/manage roles, and must be higher than the role you are trying to give access to. \ntoggleNSFW - Will toggle the NSFW quality for the channel you run it in. Your highest role in the server must have admin/manage channels to do this. \npurge [num] - Purges the number of messages requested (This number does not include the ' + prefix + 'purge message, which is also deleted). \ncreatePoll - Follow instruction to create a poll. \npollOptions - displays the options to the current poll. \npollResults - displays the current results of the poll. \naddCustomResponse [custom] - allows users to add a custom response to a poll. \nvote [optionNum] - votes for the option number given. \nclosePoll - Can only be done by poll creator, closes poll and displas results. \nall that apply polls, createAtappPoll, pollAtappOptions, addCustomAtappResponse [custom], pollAtappResults, voteAtapp [vote], closeAtappPoll. These work the same as regular polls, but users can choose multiple responses \ncustomCommand[1/2/3] - allows users to create custom commands by following instructions.'
 					}, function(err, res){
 						if (err) throw err;
 						bot.sendMessage({
@@ -1908,7 +1909,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 				break;
 			//Create a poll
 			case 'createPoll':
-				if (message.toLowerCase() == "gcd.createpoll" && !someArray.includes(userID) && !openPoll) {
+				if (message.toLowerCase() == prefix + "createpoll" && !someArray.includes(userID) && !openPoll) {
 					pollOpener = userID;
 				  someArray.push(userID)
 				  bot.sendMessage({
@@ -2342,7 +2343,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 						} else {
 							bot.sendMessage({
 								to: channelID,
-								message: bot.users[userID].username + ', you don\'t have a profile with GCD yet. Please run "gcd.profile"'
+								message: bot.users[userID].username + ', you don\'t have a profile with GCD yet. Please run "' + prefix + 'profile"'
 							});
 						}
 					});
@@ -2382,7 +2383,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 						} else {
 							bot.sendMessage({
 								to: channelID,
-								message: bot.users[userID].username + ', you don\'t have a profile with GCD yet. Please run "gcd.profile"'
+								message: bot.users[userID].username + ', you don\'t have a profile with GCD yet. Please run "' + prefix + 'profile"'
 							});
 						}
 					});
@@ -2474,7 +2475,7 @@ bot.on('message', function (user, userID, channelID, message, evt) {
 											}
 											],
 										footer: {
-											text: 'To accept these terms, please DM GCD "gcd.accept iAcPT"'
+											text: 'To accept these terms, please DM GCD "' + prefix + 'accept iAcPT"'
 										}
 									}
 								});


### PR DESCRIPTION
-made gcd iaccept function more readable and reduced unnecessary checks

-reduced hardcoded prefix to make changing the prefix much faster if needed (and also generally good coding practice for reuse too)
TODO: make the bot access the database for the prefix so the last few hardcoding instances are gone

-leads to the possibility of letting the owner change the main prefix fast (including in the help documents, custom status, and other places)!

INFO: Clarification needed for line 876 ish. Why change the prefix to ;? Does this impact other servers? Otherwise what's the point in setting the prefix twice?
INFO: What should we do about line 509? the gcd.gcd.gcd... stuff